### PR TITLE
Fix collector selection logic for metrics and correct tests

### DIFF
--- a/lib/kolekti/runner.rb
+++ b/lib/kolekti/runner.rb
@@ -40,7 +40,10 @@ module Kolekti
 
     def find_collectors
       collectors = wanted_metric_configurations.map do |code, metric_configuration|
-        found_collector = Kolekti.collectors.find { |collector| collector.supported_metrics.include? code }
+        collector_name = metric_configuration.metric.metric_collector_name
+        found_collector = Kolekti.collectors.find { |collector|
+          collector.name == collector_name && collector.supported_metrics.include?(code.to_sym)
+        }
         raise UnavailableMetricError.new("No Metric Collector for metric code #{code}") if found_collector.nil?
 
         found_collector

--- a/spec/factories/another_dummy_collector.rb
+++ b/spec/factories/another_dummy_collector.rb
@@ -1,7 +1,7 @@
 class AnotherDummyCollector < Kolekti::Collector
   def initialize
     mc = FactoryGirl.build(:other_metric_configuration)
-    super('name', 'description', { mc.metric.code => mc.metric })
+    super(mc.metric.metric_collector_name, 'description', { mc.metric.code.to_sym => mc.metric })
   end
 
   def self.available?

--- a/spec/factories/dummy_collector.rb
+++ b/spec/factories/dummy_collector.rb
@@ -1,7 +1,7 @@
 class DummyCollector < Kolekti::Collector
   def initialize
     mc = FactoryGirl.build(:metric_configuration)
-    super('name', 'description', { mc.metric.code => mc.metric })
+    super(mc.metric.metric_collector_name, 'description', { mc.metric.code.to_sym => mc.metric })
   end
 
   def self.available?

--- a/spec/factories/metric_configurations.rb
+++ b/spec/factories/metric_configurations.rb
@@ -2,7 +2,7 @@ require 'kalibro_client'
 
 FactoryGirl.define do
   factory :metric_configuration, class: KalibroClient::Entities::Configurations::MetricConfiguration do
-    metric { FactoryGirl.build(:metric) }
+    metric { FactoryGirl.build(:native_metric) }
     weight 1
     aggregation_form 'mean'
     reading_group_id 1
@@ -14,7 +14,6 @@ FactoryGirl.define do
   end
 
   factory :other_metric_configuration, parent: :metric_configuration do
-    metric { FactoryGirl.build(:metric, code: 'other') }
+    metric { FactoryGirl.build(:native_metric, metric_collector_name: 'OtherNativeTestCollector', code: 'other') }
   end
-
 end


### PR DESCRIPTION
Ensure metric codes are looked up using symbols when deciding which
collector should handle a metric. Fix some factories to properly use
native metrics, and make the dummy colletors use the name matching the
supported metrics.

Signed-off-by: Eduardo Silva Araújo duduktamg@hotmail.com
