### PR TITLE
Throw error when creating duplicated 'tree_metric_result' (Closes #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The Kolekti gem provides a basic API for KalibroProcessor's collectors
 
 ## Unreleased
 
+* Handle 'tree_metric_result' with same modules or configs
+
 ## v1.1.3 - 15/04/2016
 
 * Update Collector#collect_metrics signature

--- a/spec/kolekti/memory_persistence_strategy_spec.rb
+++ b/spec/kolekti/memory_persistence_strategy_spec.rb
@@ -18,10 +18,28 @@ describe Kolekti::MemoryPersistenceStrategy do
       }
     }
 
-    it 'is expected to store the result in memory' do
-      subject.create_tree_metric_result(metric_configuration, module_name, value, granularity)
+    context 'with valid metric configuration' do
+      it 'is expected to store the result in memory' do
+        subject.create_tree_metric_result(metric_configuration, module_name, value, granularity)
+        expect(subject.tree_metric_results).to eq([result_hash])
+      end
+    end
 
-      expect(subject.tree_metric_results).to eq([result_hash])
+    context 'with duplicated module name and configuration' do
+      it 'is expected to throw an error' do
+        subject.create_tree_metric_result(metric_configuration, module_name, value, granularity)
+        expect{
+          subject.create_tree_metric_result(metric_configuration, module_name, value, granularity)
+        }.to raise_error(Kolekti::AlreadyTakenModuleException)
+      end
+    end
+
+    context 'with duplicated module name xor configuration' do
+      it 'is expected to increase total number of tree_metric_results' do
+        subject.create_tree_metric_result(metric_configuration, module_name, value, granularity)
+        subject.create_tree_metric_result(metric_configuration, 'myawezomemodule', value, granularity)
+        expect(subject.tree_metric_results.count).to eq(2)
+      end
     end
   end
 


### PR DESCRIPTION
Throw error when creating duplicated 'tree_metric_result'
- creates exception class to be throw when duplicated 'tree_metric_result' is created (same module name or same configuration)
- adds one context to handle multiple 'tree_metric_result' with same module name or same configuration)
